### PR TITLE
Add TensorRT GhostNet acceleration project link to the resource list

### DIFF
--- a/ghostnet_pytorch/readme.md
+++ b/ghostnet_pytorch/readme.md
@@ -72,3 +72,4 @@ This repo provides the TensorFlow/PyTorch code of GhostNet. Other versions and a
 5. Human pose estimation: [code](https://github.com/tensorboy/centerpose/blob/master/lib/models/backbones/ghost_net.py)
 6. YOLO with GhostNet backbone: [code](https://github.com/HaloTrouvaille/YOLO-Multi-Backbones-Attention)
 7. Face recognition: [cavaface](https://github.com/cavalleria/cavaface.pytorch/blob/master/backbone/ghostnet.py), [FaceX-Zoo](https://github.com/JDAI-CV/FaceX-Zoo), [TFace](https://github.com/Tencent/TFace)
+8. TensorRT accelerated GhostNet: [code](https://github.com/wang-xinyu/tensorrtx/tree/master/ghostnet)


### PR DESCRIPTION
This PR adds a new entry to the resource list related to GhostNet implementations. The added resource is for a project that provides ```TensorRT```🚀 acceleration for GhostNetv1 && GhostNetv2. 


